### PR TITLE
Make WordCountGraph a pure component for perf

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "react-dimensions": "^1.0.2",
     "react-dom": "^0.14.7",
     "react-hot-loader": "^1.3.0",
+    "react-pure-render": "^1.0.2",
     "react-redux": "^4.2.0",
     "react-router": "^1.0.2",
     "react-spinner": "^0.2.3",

--- a/src/components/WordCountGraph/index.js
+++ b/src/components/WordCountGraph/index.js
@@ -1,19 +1,25 @@
-import React from "react";
+import React, {Component} from "react";
+import shouldPureComponentUpdate from "react-pure-render/function";
 import Dimensions from "react-dimensions";
 import {VictoryChart, VictoryLine} from "victory";
 
-function WordCountGraph({data, containerWidth}) {
-  const chartData = data.toArray().map((datum) => {
-    return {
-      x: datum.get("met_start"),
-      y: Number(datum.getIn(["data", "count"]))
-    };
-  });
+class WordCountGraph extends Component {
+  shouldComponentUpdate = shouldPureComponentUpdate;
 
-  return (<VictoryChart width={containerWidth}
-                        height={containerWidth/(16/4)}>
-    <VictoryLine data={chartData} />
-  </VictoryChart>);
+  render() {
+    const {data, containerWidth} = this.props;
+    const chartData = data.toArray().map((datum) => {
+      return {
+        x: datum.get("met_start"),
+        y: Number(datum.getIn(["data", "count"]))
+      };
+    });
+
+    return (<VictoryChart width={containerWidth}
+                          height={containerWidth/(16/4)}>
+      <VictoryLine data={chartData} />
+    </VictoryChart>);
+  }
 }
 
 export default Dimensions()(WordCountGraph);


### PR DESCRIPTION
@jbrady42 was reporting big CPU problems

# before
![beforeperf](https://cloud.githubusercontent.com/assets/2192970/12908142/69c49fa4-ceb9-11e5-8178-65ee46921c3d.png)

At 40 seconds is when I start playing the audio. Massive cpu spike

# after
![afterperf](https://cloud.githubusercontent.com/assets/2192970/12908145/6fb0edd2-ceb9-11e5-9a43-ff84898f511a.png)

At 50 seconds I start playing the audio. issue fixed