### PR TITLE
Fixed playTime event values.

### DIFF
--- a/src/middleware.js
+++ b/src/middleware.js
@@ -36,7 +36,7 @@ export function googleAnalytics(store) {
         const isPlaying = !!store.getState().audio.playing || !!action.playing;
         if (isPlaying && action.time) {
           // Audio has started playing, so start sending play time events.
-          sendPlayTimeEvent(action.time);
+          sendPlayTimeEvent(Math.round(1000 * action.time));
         }
 
         break;


### PR DESCRIPTION
Started sending audio play time in milliseconds instead seconds because Google Analytics event values must be integers (see [here](https://developers.google.com/analytics/devguides/collection/analyticsjs/field-reference#eventValue)).
