### PR TITLE
fix(webpack): fix dev server unable to compile

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -96,5 +96,11 @@ module.exports = {
 
   externals: {
     "ga": "ga"
+  },
+
+  node: {
+    // nodejs built-in modules used by xmlhttprequest
+    fs: "empty",
+    child_process: "empty"
   }
 };


### PR DESCRIPTION
node built-in modules not needed for d3-request dependency

admittedly I'm unable to run the tests yet as I'm unsure how to configure a chrome launcher on my pixelbook, hoping Travis is still building these